### PR TITLE
fix: soften MCP test error handling

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -59,8 +59,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         sendResponse({ ok: true });
       })
       .catch((error) => {
-        console.error('翻译测试失败:', error);
-        sendResponse({ ok: false, error: error.message || '测试失败' });
+        const message = error?.message || '测试失败';
+        console.warn('[translator] 测试失败:', message);
+        sendResponse({ ok: false, error: message });
       });
     return true;
   }


### PR DESCRIPTION
## Summary
- downgrade translation test failures to warning and bubble the message to UI
- avoid chrome://extensions reporting fatal errors when network/API rejects test

## Testing
- MT_QA_HOOKS=1 npm run build
- node scripts/mcp/capture-uids.mjs --update --write-batches
- npm run test:mcp